### PR TITLE
feat: add detailed fasta output

### DIFF
--- a/bin/make_detailed_consensus.py
+++ b/bin/make_detailed_consensus.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+import argparse
+import pandas as pd
+from Bio import SeqIO
+from Bio.Seq import Seq, MutableSeq
+import itertools
+
+def add_extra_characters(fasta_file, snps_vcf, allsites_vcf, repeat_mask, output_file):
+    # Read the fasta file
+    fasta_data = SeqIO.read(fasta_file, 'fasta')
+    seq = MutableSeq(fasta_data.seq)
+    ref_length = len(seq)
+
+    # Find all zero depth positions, according to allsites vcf
+    allsites_df = pd.read_csv(allsites_vcf, sep='\t', comment="#", header=None,
+                           names=['chrome', 'POS', 'id', 'ref', 'alt', 'qual', 'filter', 'info', 'format', 'sample'],
+                           dtype=str)
+    allsites_df['POS'] = allsites_df['POS'].astype(int)
+
+    # Filter out rows where 'info' contains "DP=0"
+    allsites_df = allsites_df[~allsites_df['info'].str.contains("DP=0")]
+
+    nonzero_positions = set(allsites_df['POS'])
+    zero_positions = set(range(1, ref_length + 1)) - nonzero_positions
+
+    # Get repeat regions from mask
+    repeat_df = pd.read_csv(repeat_mask, sep='\t', comment="#", header=None,
+                            names=['chrome', 'start', 'end', 'RPT'])
+    ranges = [(start, end) for start, end in zip(repeat_df['start'], repeat_df['end'])]
+    repeat_positions = set(itertools.chain.from_iterable(
+        [range(start, end+1) for start, end in ranges]
+    ))
+
+    snps_df = pd.read_csv(snps_vcf, sep='\t', comment="#", header=None,
+                          names=['chrome', 'POS', 'id', 'ref', 'alt', 'qual', 
+                                 'filter', 'info', 'format', 'sample'])
+    print(snps_df.head())
+    filtered_locations = set(snps_df[snps_df['filter'] != 'PASS']['POS'])
+    het_positions = set(snps_df[snps_df['filter'].str.contains('HetroZ')]['POS'])
+    null_gt_positions = set(snps_df[snps_df['sample'].str.contains('./.', regex=False)]['POS'])
+
+
+    # Replace in order of precedence
+    already_changed = set()
+    position_lists = [repeat_positions, zero_positions, null_gt_positions, het_positions, filtered_locations]
+    characters = ['R', 'N', 'X', 'H', 'F']
+    for pos_list, character in zip(position_lists, characters):
+        pos_list -= already_changed
+        print("Replacing {} positions with {}".format(len(pos_list), character))
+        for position in pos_list:
+            seq[position-1] = character
+        already_changed = already_changed | pos_list
+    
+    fasta_data.seq = Seq(str(seq))
+
+    # Write the modified fasta sequence to a new file
+    with open(output_file, 'w') as file:
+        SeqIO.write(fasta_data, file, 'fasta')
+
+if __name__ == '__main__':
+    # Parse command-line arguments
+    parser = argparse.ArgumentParser(description='Mask positions with depth 0 in a fasta file')
+    parser.add_argument('-f', '--fasta_file', help='Path to the fasta file')
+    parser.add_argument('-a', '--allsites_vcf', help='Path to the allsites vcf file')
+    parser.add_argument('-s', '--snps_vcf', help='Path to the snps vcf file')
+    parser.add_argument('-r', '--repeat_mask', help='Path to the repeat mask file')
+    parser.add_argument('-o', '--output_file', help='Path to the output file')
+    args = parser.parse_args()
+
+    # Call the mask_zero_depth function
+    add_extra_characters(args.fasta_file, args.snps_vcf, args.allsites_vcf,
+                    args.repeat_mask, args.output_file)

--- a/conda/bugflow_biopython.yaml
+++ b/conda/bugflow_biopython.yaml
@@ -1,0 +1,11 @@
+name: biopython
+channels:
+  - conda-forge
+  - bioconda
+  - r
+  - defaults
+dependencies:
+  - biopython
+  - seqkit
+  - bcftools
+  - pandas

--- a/docker/bugflow_biopython.Dockerfile
+++ b/docker/bugflow_biopython.Dockerfile
@@ -1,0 +1,9 @@
+FROM oxfordmmm/bugflow_base:latest  
+
+################## METADATA ###################### 
+LABEL about.summary="Image for biopython prcoesses of BUGflow: nextflow based pipeline for processing bacterial sequencing data"
+
+################## MAINTAINER ###################### 
+LABEL maintainer="David Eyre <david.eyre@bdi.ox.ac.uk>"
+
+RUN mamba env update -n base --file bugflow_conda/bugflow_biopython.yaml


### PR DESCRIPTION
Combines outputs to produce a detailed consensus fasta file
Uses extra letters:
        - N = no coverage
        - F = filtered
        - R = repeat region
        - H = heterozygous
        - X = null genotype

Also fixes zero depth issue:
When bcftools creates a pileup it won't actually include a row for every site. Some places it explicitly gives DP=0, but others are excluded.
Now the full fasta will label these sites as N, whereas all zero-depth sites will be reference in the standard fasta output